### PR TITLE
Add precise width and height controls for cropping

### DIFF
--- a/src/main/java/pixelitor/transform/TransformSupport.java
+++ b/src/main/java/pixelitor/transform/TransformSupport.java
@@ -135,6 +135,26 @@ public class TransformSupport {
         handles.updateRect(compSpaceRect);
     }
 
+    /**
+     * Set size of selection in image space
+     */
+    public void setSize(int width, int height, ImageComponent ic) {
+
+        this.imageSpaceRect.setRect(this.imageSpaceRect.getX(), this.imageSpaceRect.getY(), width, height);
+
+        double viewScale = ic.getZoomLevel().getViewScale();
+        this.compSpaceRect.setSize((int) (width * viewScale), (int) (height * viewScale));
+        handles.updateRect(compSpaceRect);
+        ic.repaint();
+    }
+
+    /**
+     * Return true while the user is adjusting the handles
+     */
+    public boolean isAdjusting() {
+        return adjusting;
+    }
+
     private void recalculateImageSpaceRect(ImageComponent ic) {
         Rectangle2D possiblyNegativeRect = ic.fromComponentToImageSpace(compSpaceRect);
         this.imageSpaceRect = Utils.toPositiveRect(possiblyNegativeRect);


### PR DESCRIPTION
Few problems to mention:
- cannot find constants for image canvas max width/height.  Creating new too large file ends with crash, even worse when resizing image. In crop tool I used max 300000px. It would be beneficial to have constants for these.
- possible rounding problems during conversion between view and image space (zoom other than 100%) Possible solution would be to always work in image space and scale only during rendering.