### PR TITLE
Add guidelines: golden spiral, triangles, grid

### DIFF
--- a/src/main/java/pixelitor/tools/crop/CropTool.java
+++ b/src/main/java/pixelitor/tools/crop/CropTool.java
@@ -341,8 +341,9 @@ public class CropTool extends DragTool {
             g2.setClip(componentSpaceVisiblePart);
 
             // draw guidelines
-            RectGuidelineType guidelineType = (RectGuidelineType) guidesSelector.getSelectedItem();
-            rectGuideline.draw(cropRect.getCo(), guidelineType, g2);
+            rectGuideline.setType((RectGuidelineType) guidesSelector.getSelectedItem());
+            rectGuideline.setOrientation(0);
+            rectGuideline.draw(cropRect.getCo(), g2);
 
             cropBox.paintHandles(g2);
         }

--- a/src/main/java/pixelitor/tools/guidelines/RectGuideline.java
+++ b/src/main/java/pixelitor/tools/guidelines/RectGuideline.java
@@ -19,15 +19,14 @@ package pixelitor.tools.guidelines;
 
 import pixelitor.guides.Guides;
 
-import java.awt.Graphics2D;
+import java.awt.*;
+import java.awt.geom.Arc2D;
 import java.awt.geom.Line2D;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
 import static java.awt.Color.BLACK;
 import static java.awt.Color.WHITE;
-import static pixelitor.tools.guidelines.RectGuidelineType.DIAGONALS;
-import static pixelitor.tools.guidelines.RectGuidelineType.GOLDEN_SECTIONS;
-import static pixelitor.tools.guidelines.RectGuidelineType.RULE_OF_THIRDS;
 
 /**
  * Crop guidelines renderer
@@ -35,35 +34,68 @@ import static pixelitor.tools.guidelines.RectGuidelineType.RULE_OF_THIRDS;
 public class RectGuideline {
 
     private Graphics2D g2;
+    private RectGuidelineType type = RectGuidelineType.NONE;
+    private int orientation = 0;
+    private final static double GOLDEN_RATIO = 1.618;
 
-    public void draw(Rectangle2D rect, RectGuidelineType type, Graphics2D g2)
+    public RectGuidelineType getType()
     {
-        if (type == RectGuidelineType.NONE) {
-            return;
-        }
+        return type;
+    }
 
+    public void setType(RectGuidelineType type)
+    {
+        this.type = type;
+    }
+
+    public int getOrientation() {
+        return orientation;
+    }
+
+    public void setOrientation(int orientation)
+    {
+        this.orientation = orientation % 4;
+    }
+
+    public void draw(Rectangle2D rect, Graphics2D g2)
+    {
         this.g2 = g2;
-        if (type == RULE_OF_THIRDS) {
-            drawRuleOfThirds(rect);
-        } else if (type == GOLDEN_SECTIONS) {
-            drawGoldenSections(rect);
-        } else if (type == DIAGONALS) {
-            drawDiagonals(rect);
+        switch (type) {
+            case NONE:
+                break;
+            case RULE_OF_THIRDS:
+                drawRuleOfThirds(rect);
+                break;
+            case GOLDEN_SECTIONS:
+                drawGoldenSections(rect);
+                break;
+            case GOLDEN_SPIRAL:
+                drawGoldenSpiral(rect);
+                break;
+            case DIAGONALS:
+                drawDiagonals(rect);
+                break;
+            case TRIANGLES:
+                drawTriangles(rect);
+                break;
+            case GRID:
+                drawGrid(rect);
+                break;
         }
     }
 
-    private void drawLines(Line2D[] lines)
+    private void drawShapes(Shape[] shapes)
     {
         g2.setStroke(Guides.INNER_STROKE);
         g2.setColor(BLACK);
-        for (Line2D line : lines) {
-            g2.draw(line);
+        for (Shape shape : shapes) {
+            g2.draw(shape);
         }
 
         g2.setStroke(Guides.OUTER_STROKE);
         g2.setColor(WHITE);
-        for (Line2D line : lines) {
-            g2.draw(line);
+        for (Shape shape : shapes) {
+            g2.draw(shape);
         }
     }
 
@@ -90,7 +122,7 @@ public class RectGuideline {
         lines[2] = new Line2D.Double(x1, y1, x2, y1);
         lines[3] = new Line2D.Double(x1, y2, x2, y2);
 
-        drawLines(lines);
+        drawShapes(lines);
     }
 
     private void drawRuleOfThirds(Rectangle2D rect)
@@ -100,7 +132,7 @@ public class RectGuideline {
 
     private void drawGoldenSections(Rectangle2D rect)
     {
-        drawSections(rect, 1.618);
+        drawSections(rect, GOLDEN_RATIO);
     }
 
     private void drawDiagonals(Rectangle2D rect)
@@ -140,6 +172,212 @@ public class RectGuideline {
             lines[3] = new Line2D.Double(x1, y2, x2, y1);
         }
 
-        drawLines(lines);
+        drawShapes(lines);
+    }
+
+    private void drawGrid(Rectangle2D rect)
+    {
+        int gridSize = 50;
+        int gridCountH = 1 + 2*((int) (rect.getHeight() / 2 / gridSize));
+        int gridCountV = 1 + 2*((int) (rect.getWidth() / 2 / gridSize));
+        double gridOffsetH = (rect.getHeight() - (gridCountH+1) * gridSize) / 2;
+        double gridOffsetV = (rect.getWidth() - (gridCountV+1) * gridSize) / 2;
+        Line2D[] lines = new Line2D.Double[gridCountH + gridCountV];
+
+        // horizontal lines (change only y position)
+        double x1 = rect.getX();
+        double x2 = rect.getX() + rect.getWidth();
+        for (int i = 0; i < gridCountH; i++) {
+            double yh = rect.getY() + (i+1) * gridSize + gridOffsetH;
+            lines[i] = new Line2D.Double(x1, yh,  x2, yh);
+        }
+
+        // vertical lines (change only x position)
+        double y1 = rect.getY();
+        double y2 = rect.getY()+ rect.getHeight();
+        for (int i = 0; i < gridCountV; i++) {
+            double xv = rect.getX() + (i+1) * gridSize + gridOffsetV;
+            lines[gridCountH+i] = new Line2D.Double(xv, y1, xv, y2);
+        }
+
+        drawShapes(lines);
+    }
+
+    /**
+     * Get projected point P' of P on given line
+     * @return projected point p.
+     */
+    private Point2D.Double getProjectedPointOnLine(Line2D line, Point2D.Double p)
+    {
+        Point2D.Double l1 = (Point2D.Double) line.getP1();
+        Point2D.Double l2 = (Point2D.Double) line.getP2();
+
+        // get dot product of vectors v1, v2
+        Point2D.Double v1 = new Point2D.Double(l2.x - l1.x, l2.y - l1.y);
+        Point2D.Double v2 = new Point2D.Double(p.x - l1.x, p.y - l1.y);
+        double d = v1.x * v2.x + v1.y * v2.y;
+
+        // get squared length of vector v1
+        double v1Length = v1.x * v1.x + v1.y * v1.y;
+        if (v1Length == 0) {
+            return l1;
+        }
+
+        return new Point2D.Double(
+            (int)(l1.x + (d * v1.x) / v1Length),
+            (int)(l1.y + (d * v1.y) / v1Length));
+    }
+
+    /**
+     * Get orthogonal line to given line that pass through point P
+     * @return orthogonal line
+     */
+    private Line2D getOrthogonalLineThroughPoint(Line2D line, Point2D.Double p)
+    {
+        return new Line2D.Double(p, getProjectedPointOnLine(line, p));
+    }
+
+    private void drawTriangles(Rectangle2D rect)
+    {
+        Line2D[] lines = new Line2D.Double[3];
+        double x1, x2, y1, y2;
+
+        if ((orientation % 2) == 0) {
+            // diagonal line from top left to bottom right
+            x1 = rect.getX();
+            y1 = rect.getY();
+            x2 = rect.getX() + rect.getWidth();
+            y2 = rect.getY() + rect.getHeight();
+        } else {
+            // diagonal line form bottom left to top right
+            x1 = rect.getX();
+            y1 = rect.getY() + rect.getHeight();
+            x2 = rect.getX() + rect.getWidth();
+            y2 = rect.getY();
+        }
+
+        lines[0] = new Line2D.Double(x1, y1, x2, y2);
+        lines[1] = getOrthogonalLineThroughPoint(lines[0], new Point2D.Double(x1, y2));
+        lines[2] = getOrthogonalLineThroughPoint(lines[0], new Point2D.Double(x2, y1));
+
+        drawShapes(lines);
+    }
+
+    private void drawGoldenSpiral(Rectangle2D rect)
+    {
+        Shape[] arc2D = new Arc2D.Double[11];
+        double angle;
+        double arcWidth = rect.getWidth() / GOLDEN_RATIO;
+        double arcHeight = rect.getHeight();
+        Point2D.Double center;
+
+        switch (orientation % 4) {
+            case 0:
+            {
+                angle = 180;
+                center = new Point2D.Double(rect.getX()+arcWidth, rect.getY() + arcHeight);
+
+                for(int i=0;;) {
+                    arc2D[i] = new Arc2D.Double(
+                        (center.getX() - arcWidth),
+                        (center.getY() - arcHeight),
+                        arcWidth*2,
+                        arcHeight*2,
+                        angle,
+                        -90,
+                        Arc2D.OPEN);
+
+                    if (++i > 10) break;
+                    angle -= 90;
+                    arcWidth = arcWidth / GOLDEN_RATIO;
+                    arcHeight = arcHeight / GOLDEN_RATIO;
+                    center.setLocation(
+                        center.getX() + Math.sin( Math.toRadians(  90 - angle ) ) * arcWidth  / GOLDEN_RATIO,
+                        center.getY() - Math.sin( Math.toRadians( 180 - angle ) ) * arcHeight / GOLDEN_RATIO
+                    );
+                }
+            }
+            break;
+            case 1:
+            {
+                angle = 180;
+                center = new Point2D.Double(rect.getX()+arcWidth, rect.getY());
+
+                for(int i=0;;) {
+                    arc2D[i] = new Arc2D.Double(
+                        (center.getX() - arcWidth),
+                        (center.getY() - arcHeight),
+                        arcWidth*2,
+                        arcHeight*2,
+                        angle,
+                        90,
+                        Arc2D.OPEN);
+
+                    if (++i > 10) break;
+                    angle += 90;
+                    arcWidth = arcWidth / GOLDEN_RATIO;
+                    arcHeight = arcHeight / GOLDEN_RATIO;
+                    center.setLocation(
+                        center.getX() - Math.sin( Math.toRadians(  -90 + angle ) ) * arcWidth  / GOLDEN_RATIO,
+                        center.getY() + Math.sin( Math.toRadians( -180 + angle ) ) * arcHeight / GOLDEN_RATIO
+                    );
+                }
+            }
+            break;
+            case 2:
+            {
+                angle = 0;
+                center = new Point2D.Double(rect.getX()+(rect.getWidth()-arcWidth), rect.getY() + rect.getHeight());
+
+                for(int i=0;;) {
+                    arc2D[i] = new Arc2D.Double(
+                        (center.getX() - arcWidth),
+                        (center.getY() - arcHeight),
+                        arcWidth*2,
+                        arcHeight*2,
+                        angle,
+                        90,
+                        Arc2D.OPEN);
+
+                    if (++i > 10) break;
+                    angle += 90;
+                    arcWidth = arcWidth / GOLDEN_RATIO;
+                    arcHeight = arcHeight / GOLDEN_RATIO;
+                    center.setLocation(
+                        center.getX() + Math.sin( Math.toRadians( 90 + angle ) ) * arcWidth  / GOLDEN_RATIO,
+                        center.getY() - Math.sin( Math.toRadians(  0 + angle ) ) * arcHeight / GOLDEN_RATIO
+                    );
+                }
+            }
+            break;
+            case 3:
+            {
+                angle = 0;
+                center = new Point2D.Double(rect.getX()+(rect.getWidth()-arcWidth), rect.getY());
+
+                for(int i=0;;) {
+                    arc2D[i] = new Arc2D.Double(
+                        (center.getX() - arcWidth),
+                        (center.getY() - arcHeight),
+                        arcWidth*2,
+                        arcHeight*2,
+                        angle,
+                        -90,
+                        Arc2D.OPEN);
+
+                    if (++i > 10) break;
+                    angle -= 90;
+                    arcWidth = arcWidth / GOLDEN_RATIO;
+                    arcHeight = arcHeight / GOLDEN_RATIO;
+                    center.setLocation(
+                        center.getX() + Math.sin( Math.toRadians( 90 - angle ) ) * arcWidth  / GOLDEN_RATIO,
+                        center.getY() + Math.sin( Math.toRadians(  0 - angle ) ) * arcHeight / GOLDEN_RATIO
+                    );
+                }
+            }
+            break;
+        }
+
+        drawShapes(arc2D);
     }
 }

--- a/src/main/java/pixelitor/tools/guidelines/RectGuidelineType.java
+++ b/src/main/java/pixelitor/tools/guidelines/RectGuidelineType.java
@@ -24,7 +24,10 @@ public enum RectGuidelineType {
     NONE("None"),
     RULE_OF_THIRDS("Rule of Thirds"),
     GOLDEN_SECTIONS("Golden Sections"),
-    DIAGONALS("Diagonal Lines");
+    GOLDEN_SPIRAL("Golden Spiral"),
+    DIAGONALS("Diagonal Lines"),
+    TRIANGLES("Triangles"),
+    GRID("Grid");
 
     private final String guiName;
 

--- a/src/test/java/pixelitor/tools/guidelines/RectGuidelineTest.java
+++ b/src/test/java/pixelitor/tools/guidelines/RectGuidelineTest.java
@@ -20,28 +20,28 @@ package pixelitor.tools.guidelines;
 import org.junit.Test;
 
 import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.geom.Arc2D;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class RectGuidelineTest {
 
     private RectGuideline rectGuideline;
 
     @Test
-    public void draw_GuideLineType_NONE() {
+    public void draw_Type_NONE() {
 
         Rectangle2D rect = new Rectangle2D.Double(0, 0, 90, 30);
         Graphics2D g2 = mock(Graphics2D.class);
 
         rectGuideline = new RectGuideline();
-        rectGuideline.draw(rect, RectGuidelineType.NONE, g2);
+        rectGuideline.setType(RectGuidelineType.NONE);
+        rectGuideline.draw(rect, g2);
 
         verify(g2, never()).draw(any(Line2D.class));
     }
@@ -54,7 +54,8 @@ public class RectGuidelineTest {
         Graphics2D g2 = mock(Graphics2D.class);
 
         rectGuideline = new RectGuideline();
-        rectGuideline.draw(rect, RectGuidelineType.RULE_OF_THIRDS, g2);
+        rectGuideline.setType(RectGuidelineType.RULE_OF_THIRDS);
+        rectGuideline.draw(rect, g2);
 
         verify(g2, times(2)).draw(refEq(new Line2D.Double(30, 0, 30, 12)));
         verify(g2, times(2)).draw(refEq(new Line2D.Double(60, 0, 60, 12)));
@@ -69,7 +70,8 @@ public class RectGuidelineTest {
         Graphics2D g2 = mock(Graphics2D.class);
 
         rectGuideline = new RectGuideline();
-        rectGuideline.draw(rect, RectGuidelineType.GOLDEN_SECTIONS, g2);
+        rectGuideline.setType(RectGuidelineType.GOLDEN_SECTIONS);
+        rectGuideline.draw(rect, g2);
 
         double phi = 1.618;
         double sectionWidth = rect.getWidth() / phi;
@@ -89,7 +91,8 @@ public class RectGuidelineTest {
         Graphics2D g2 = mock(Graphics2D.class);
 
         rectGuideline = new RectGuideline();
-        rectGuideline.draw(rect, RectGuidelineType.DIAGONALS, g2);
+        rectGuideline.setType(RectGuidelineType.DIAGONALS);
+        rectGuideline.draw(rect, g2);
 
         verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 0, 12, 12)));
         verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 12, 12, 0)));
@@ -105,11 +108,128 @@ public class RectGuidelineTest {
         Graphics2D g2 = mock(Graphics2D.class);
 
         rectGuideline = new RectGuideline();
-        rectGuideline.draw(rect, RectGuidelineType.DIAGONALS, g2);
+        rectGuideline.setType(RectGuidelineType.DIAGONALS);
+        rectGuideline.draw(rect, g2);
 
         verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 0, 12, 12)));
         verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 12, 12, 0)));
         verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 90, 12, 90 - 12)));
         verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 90 - 12, 12, 90)));
+    }
+
+    @Test
+    public void draw_Type_TRIANGLES_top_left_to_bottom_down()
+    {
+
+        // orientation: 0 (diagonal line from top left to bottom down)
+        Rectangle2D rect = new Rectangle2D.Double(0, 0, 10, 10);
+        Graphics2D g2 = mock(Graphics2D.class);
+
+        rectGuideline = new RectGuideline();
+        rectGuideline.setType(RectGuidelineType.TRIANGLES);
+        rectGuideline.setOrientation(0);
+        rectGuideline.draw(rect, g2);
+
+        Point.Double p = new Point.Double(5,5);
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 0, 10, 10)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 10, p.x, p.y)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(10, 0, p.x, p.y)));
+    }
+
+    @Test
+    public void draw_Type_TRIANGLES_bottom_down_to_top_left()
+    {
+        // orientation: 1 (diagonal line from bottom down to top left)
+        Rectangle2D rect = new Rectangle2D.Double(0, 0, 10, 10);
+        Graphics2D g2 = mock(Graphics2D.class);
+
+        rectGuideline = new RectGuideline();
+        rectGuideline.setType(RectGuidelineType.TRIANGLES);
+        rectGuideline.setOrientation(1);
+        rectGuideline.draw(rect, g2);
+
+        Point.Double p = new Point.Double(5,5);
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 10, 10, 0)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 0, p.x, p.y)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(10, 10, p.x, p.y)));
+    }
+
+    @Test
+    public void draw_Type_GRID_less_than_2xSize()
+    {
+        Rectangle2D rect = new Rectangle2D.Double(0, 0, 90, 90);
+        Graphics2D g2 = mock(Graphics2D.class);
+
+        rectGuideline = new RectGuideline();
+        rectGuideline.setType(RectGuidelineType.GRID);
+        rectGuideline.draw(rect, g2);
+
+        // cross at the center (gridSize: 50)
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(45, 0, 45, 90)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 45, 90, 45)));
+        // total
+        verify(g2, atMost(4)).draw(any());
+    }
+
+    @Test
+    public void draw_Type_GRID_exact_2xSize()
+    {
+        // gridSize: 50 (one cross at the center if size less than 2xSize)
+        Rectangle2D rect = new Rectangle2D.Double(0, 0, 100, 100);
+        Graphics2D g2 = mock(Graphics2D.class);
+
+        rectGuideline = new RectGuideline();
+        rectGuideline.setType(RectGuidelineType.GRID);
+        rectGuideline.draw(rect, g2);
+
+        // cross at the center (gridSize: 50)
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(50, 0, 50, 100)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 50, 100, 50)));
+        // sides horizontal
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 0, 100, 0)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 100, 100, 100)));
+        // sides vertical
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 0, 0, 100)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(100, 0, 100, 100)));
+        // total
+        verify(g2, atMost(12)).draw(any());
+    }
+
+    @Test
+    public void draw_Type_GRID_more_than_2xSize()
+    {
+        Rectangle2D rect = new Rectangle2D.Double(0, 0, 102, 102);
+        Graphics2D g2 = mock(Graphics2D.class);
+
+        rectGuideline = new RectGuideline();
+        rectGuideline.setType(RectGuidelineType.GRID);
+        rectGuideline.draw(rect, g2);
+
+        // cross at the center (gridSize: 50)
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(51, 0, 51, 102)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 51, 102, 51)));
+        // sides horizontal
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 1, 102, 1)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(0, 101, 102, 101)));
+        // sides vertical
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(1, 0, 1, 102)));
+        verify(g2, times(2)).draw(refEq(new Line2D.Double(101, 0, 101, 102)));
+        // total
+        verify(g2, atMost(12)).draw(any());
+    }
+
+    @Test
+    public void draw_Type_SPIRAL_orientation_0()
+    {
+        // orientation: 0 (spiral that starts from bottom left)
+        Rectangle2D rect = new Rectangle2D.Double(0, 0, 10, 10);
+        Graphics2D g2 = mock(Graphics2D.class);
+
+        rectGuideline = new RectGuideline();
+        rectGuideline.setType(RectGuidelineType.GOLDEN_SPIRAL);
+        rectGuideline.setOrientation(0);
+        rectGuideline.draw(rect, g2);
+
+        verify(g2, atMost(2*11)).draw(any(Arc2D.Double.class));
     }
 }


### PR DESCRIPTION
More guidelines:
triangles and golden spiral have orientation option, but it change is not implemented yet.

The question is: how to hijack and use "o" shortcut to change orientation. Similar problem with using "Enter" to accept crop selection.