### PR TITLE
Move tool autoselection

### DIFF
--- a/src/main/java/pixelitor/Composition.java
+++ b/src/main/java/pixelitor/Composition.java
@@ -469,6 +469,10 @@ public class Composition implements Serializable {
         return layerList.get(i);
     }
 
+    public List<Layer> getLayers() {
+        return layerList;
+    }
+
     public int getNumLayers() {
         return layerList.size();
     }

--- a/src/main/java/pixelitor/filters/painters/TranslatedTextPainter.java
+++ b/src/main/java/pixelitor/filters/painters/TranslatedTextPainter.java
@@ -50,7 +50,17 @@ public class TranslatedTextPainter extends TextPainter {
      */
     public Rectangle getBoundingBox()
     {
-        return boundingBox;
+        return rotatedLayout != null? rotatedLayout.getBoundingBox() : boundingBox;
+    }
+
+    /**
+     * Return last painted bounding shape for rendered text (rect or rotated rect)
+     * Note that this is not pixel perfect shape
+     * If text was not rendered yet, returned shape is empty
+     */
+    public Shape getBoundingShape()
+    {
+        return rotatedLayout != null? rotatedLayout.asShape() : boundingBox;
     }
 
     @Override

--- a/src/main/java/pixelitor/filters/painters/TranslatedTextPainter.java
+++ b/src/main/java/pixelitor/filters/painters/TranslatedTextPainter.java
@@ -41,6 +41,17 @@ public class TranslatedTextPainter extends TextPainter {
 
     private transient RotatedRectangle rotatedLayout;
     private double rotation = 0;
+    private Rectangle boundingBox = new Rectangle();
+
+    /**
+     * Return last painted bounding box for rendered text
+     * Note that this is not pixel perfect rect
+     * If text was not rendered yet, returned rectangle is empty
+     */
+    public Rectangle getBoundingBox()
+    {
+        return boundingBox;
+    }
 
     @Override
     protected Rectangle calculateLayout(int contentWidth, int contentHeight, int width, int height) {
@@ -85,7 +96,7 @@ public class TranslatedTextPainter extends TextPainter {
 
         int tw = metrics.stringWidth(text);
         int th = metrics.getHeight();
-        Rectangle boundingBox = calculateLayout(tw, th, width, height);
+        boundingBox = calculateLayout(tw, th, width, height);
 
         AffineTransform origTX = g.getTransform();
 

--- a/src/main/java/pixelitor/layers/ContentLayer.java
+++ b/src/main/java/pixelitor/layers/ContentLayer.java
@@ -24,6 +24,8 @@ import pixelitor.history.ContentLayerMoveEdit;
 import pixelitor.history.LinkedEdit;
 import pixelitor.history.PixelitorEdit;
 
+import java.awt.*;
+
 /**
  * A layer with a content (text or image layer) that
  * can be moved/rotated.
@@ -63,6 +65,12 @@ public abstract class ContentLayer extends Layer {
     public int getTY() {
         return translationY + tmpTY;
     }
+
+    /**
+     * Returns the layer bounding box relative to the canvas
+     * I must return rect trimmed from transparent pixels
+     */
+    abstract public Rectangle getEffectiveBoundingBox();
 
     @Override
     public void startMovement() {

--- a/src/main/java/pixelitor/layers/ContentLayer.java
+++ b/src/main/java/pixelitor/layers/ContentLayer.java
@@ -68,9 +68,22 @@ public abstract class ContentLayer extends Layer {
 
     /**
      * Returns the layer bounding box relative to the canvas
-     * I must return rect trimmed from transparent pixels
+     * It must return rect trimmed from transparent pixels
      */
     abstract public Rectangle getEffectiveBoundingBox();
+
+    /**
+     * Returns the bounding box relative to the canvas used for snapping
+     * It must return rect that can help user position the layer
+     * It don't have to be the same as effective bounding box
+     */
+    abstract public Rectangle getSnappingBoundingBox();
+
+    /**
+     * Returns pixel (sRGB) at point or zero if point is out of layer
+     * Zero means black transparent pixel (omitted from hit detection)
+     */
+    abstract public int getMouseHitPixelAtPoint(Point p);
 
     @Override
     public void startMovement() {

--- a/src/main/java/pixelitor/layers/ImageLayer.java
+++ b/src/main/java/pixelitor/layers/ImageLayer.java
@@ -31,6 +31,7 @@ import pixelitor.history.PixelitorEdit;
 import pixelitor.io.PXCFormat;
 import pixelitor.selection.Selection;
 import pixelitor.tools.Tools;
+import pixelitor.utils.ImageTrimUtil;
 import pixelitor.utils.ImageUtils;
 import pixelitor.utils.Messages;
 import pixelitor.utils.Utils;
@@ -518,6 +519,16 @@ public class ImageLayer extends ContentLayer implements Drawable {
         return new Rectangle(
                 translationX, translationY,
                 image.getWidth(), image.getHeight());
+    }
+
+    @Override
+    public Rectangle getEffectiveBoundingBox() {
+        // TODO cache rect size by utilizing some BoundingBoxDirty flag
+        Rectangle rect = ImageTrimUtil.getTrimRect(getImage());
+
+        return new Rectangle(
+                translationX + rect.x, translationY + rect.y,
+                rect.width, rect.height);
     }
 
     public boolean checkImageDoesNotCoverCanvas() {

--- a/src/main/java/pixelitor/layers/SmartObject.java
+++ b/src/main/java/pixelitor/layers/SmartObject.java
@@ -23,6 +23,7 @@ import pixelitor.filters.comp.Rotate;
 import pixelitor.history.ContentLayerMoveEdit;
 
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 
@@ -81,5 +82,11 @@ public class SmartObject extends ContentLayer {
     @Override
     public void crop(Rectangle2D cropRect) {
 
+    }
+
+    @Override
+    public Rectangle getEffectiveBoundingBox() {
+        // unknown, return empty
+        return new Rectangle();
     }
 }

--- a/src/main/java/pixelitor/layers/SmartObject.java
+++ b/src/main/java/pixelitor/layers/SmartObject.java
@@ -23,6 +23,7 @@ import pixelitor.filters.comp.Rotate;
 import pixelitor.history.ContentLayerMoveEdit;
 
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
@@ -88,5 +89,17 @@ public class SmartObject extends ContentLayer {
     public Rectangle getEffectiveBoundingBox() {
         // unknown, return empty
         return new Rectangle();
+    }
+
+    @Override
+    public Rectangle getSnappingBoundingBox() {
+        // unknown, return empty
+        return new Rectangle();
+    }
+
+    @Override
+    public int getMouseHitPixelAtPoint(Point p) {
+        // unknown
+        return 0x00000000;
     }
 }

--- a/src/main/java/pixelitor/layers/TextLayer.java
+++ b/src/main/java/pixelitor/layers/TextLayer.java
@@ -39,6 +39,7 @@ import pixelitor.utils.Utils;
 import pixelitor.utils.test.RandomGUITest;
 
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -157,6 +158,12 @@ public class TextLayer extends ContentLayer {
         }
 
         return d;
+    }
+
+    @Override
+    public Rectangle getEffectiveBoundingBox()
+    {
+        return painter.getBoundingBox();
     }
 
     // TODO if a text layer has a mask, then this will apply the

--- a/src/main/java/pixelitor/layers/TextLayer.java
+++ b/src/main/java/pixelitor/layers/TextLayer.java
@@ -39,6 +39,7 @@ import pixelitor.utils.Utils;
 import pixelitor.utils.test.RandomGUITest;
 
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
@@ -161,9 +162,34 @@ public class TextLayer extends ContentLayer {
     }
 
     @Override
-    public Rectangle getEffectiveBoundingBox()
-    {
+    public Rectangle getEffectiveBoundingBox() {
         return painter.getBoundingBox();
+    }
+
+    @Override
+    public Rectangle getSnappingBoundingBox() {
+        return painter.getBoundingBox();
+    }
+
+    @Override
+    public int getMouseHitPixelAtPoint(Point p) {
+        // we treat surrounding rect as area for mouse hit detection
+        // for small font sizes or thin font styles it can be helpful
+        // for larger font sizes it could be more appropriate to use pixel perfect test
+        if (painter.getBoundingShape().contains(p)) {
+            if (hasMask() && getMask().isMaskEnabled()) {
+                BufferedImage maskImage = getMask().getImage();
+                int ix = p.x - getMask().translationX;
+                int iy = p.y - getMask().translationY;
+                if (ix >= 0 && iy >= 0 && ix < maskImage.getWidth() && iy < maskImage.getHeight()) {
+                    int maskPixel = maskImage.getRGB(ix, iy);
+                    int maskAlpha = maskPixel & 0xff;
+                    return 0x00ffffff | (maskAlpha << 24);
+                }
+            }
+            return 0xffffffff;
+        }
+        return 0x00000000;
     }
 
     // TODO if a text layer has a mask, then this will apply the

--- a/src/main/java/pixelitor/tools/DragTool.java
+++ b/src/main/java/pixelitor/tools/DragTool.java
@@ -66,6 +66,9 @@ public abstract class DragTool extends Tool {
 
     @Override
     public void mouseDragged(PMouseEvent e) {
+        if (userDrag.isCanceled()) {
+            return;
+        }
         if (spaceDragStartPoint) {
             userDrag.saveEndValues();
         }
@@ -88,6 +91,9 @@ public abstract class DragTool extends Tool {
 
     @Override
     public void mouseReleased(PMouseEvent e) {
+        if (userDrag.isCanceled()) {
+            return;
+        }
         userDrag.setEnd(e);
         userDrag.mouseReleased();
         dragFinished(e);

--- a/src/main/java/pixelitor/tools/move/ObjectsFinder.java
+++ b/src/main/java/pixelitor/tools/move/ObjectsFinder.java
@@ -16,6 +16,10 @@ import java.util.ListIterator;
  * @author Łukasz Kurzaj lukaszkurzaj@gmail.com
  */
 public class ObjectsFinder {
+
+    private final static float layerOpacityThreshold = 0.05f;
+    private final static int pixelAlphaThreshold = 30;
+
     public ObjectsFinder() {
         super();
     }
@@ -44,6 +48,7 @@ public class ObjectsFinder {
 
     public ObjectsSelection findLayerAtPoint(Point2D p, Composition stage) {
         ObjectsSelection result = new ObjectsSelection();
+        Point pPixel = new Point((int)p.getX(), (int)p.getY());
 
         // iterate in reverse order (we need to search layers from top to bottom)
         List layers = stage.getLayers();
@@ -52,13 +57,15 @@ public class ObjectsFinder {
             Layer layer = (Layer) li.previous();
             if (!(layer instanceof ContentLayer)) continue;
             if (!layer.isVisible()) continue;
-            if (layer.getOpacity() < 0.05) continue;
+            if (layer.getOpacity() < layerOpacityThreshold) continue;
 
             ContentLayer imageLayer = (ContentLayer) layer;
-            Rectangle rect = imageLayer.getEffectiveBoundingBox();
-            if (rect.contains(p)) {
+            int pixel = imageLayer.getMouseHitPixelAtPoint(pPixel);
+
+            if (((pixel >> 24) & 0xff) > pixelAlphaThreshold) {
                 result.setObject(layer);
-                result.setRect(rect);
+                result.setSnappingBoundingBox(imageLayer.getSnappingBoundingBox());
+                result.setEffectiveBoundingBox(imageLayer.getEffectiveBoundingBox());
                 break;
             }
         }

--- a/src/main/java/pixelitor/tools/move/ObjectsFinder.java
+++ b/src/main/java/pixelitor/tools/move/ObjectsFinder.java
@@ -1,0 +1,68 @@
+package pixelitor.tools.move;
+
+import pixelitor.Composition;
+import pixelitor.layers.ContentLayer;
+import pixelitor.layers.Layer;
+
+import java.awt.*;
+import java.awt.geom.Point2D;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * Search for object/s on the stage/composition from end user perspective
+ * Result may not be accurate, for example almost transparent layers are ignored
+ *
+ * @author Łukasz Kurzaj lukaszkurzaj@gmail.com
+ */
+public class ObjectsFinder {
+    public ObjectsFinder() {
+        super();
+    }
+
+    public ObjectsSelection findObjectAtPoint(Point2D p, Composition stage) {
+        ObjectsSelection result;
+
+        // search layers
+        result = findLayerAtPoint(p, stage);
+        if (!result.isEmpty()) return result;
+
+        // search guidelines
+        result = findGuideLineAtPoint(p, stage);
+        if (!result.isEmpty()) return result;
+
+        return new ObjectsSelection();
+    }
+
+    public ObjectsSelection findGuideLineAtPoint(Point2D p, Composition stage) {
+
+        ObjectsSelection result = new ObjectsSelection();
+        // here guides selection, but it would be convenient to operate on objects
+        // instead of doubles in pixel coordinates space
+        return result;
+    }
+
+    public ObjectsSelection findLayerAtPoint(Point2D p, Composition stage) {
+        ObjectsSelection result = new ObjectsSelection();
+
+        // iterate in reverse order (we need to search layers from top to bottom)
+        List layers = stage.getLayers();
+        ListIterator li = layers.listIterator(layers.size());
+        while (li.hasPrevious()) {
+            Layer layer = (Layer) li.previous();
+            if (!(layer instanceof ContentLayer)) continue;
+            if (!layer.isVisible()) continue;
+            if (layer.getOpacity() < 0.05) continue;
+
+            ContentLayer imageLayer = (ContentLayer) layer;
+            Rectangle rect = imageLayer.getEffectiveBoundingBox();
+            if (rect.contains(p)) {
+                result.setObject(layer);
+                result.setRect(rect);
+                break;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/pixelitor/tools/move/ObjectsSelection.java
+++ b/src/main/java/pixelitor/tools/move/ObjectsSelection.java
@@ -3,24 +3,18 @@ package pixelitor.tools.move;
 import java.awt.geom.Rectangle2D;
 
 /**
- * Represents objects selection on stage. It keep track on objects bounding box
- * Bounding box must be represented in canvas coordinate space
+ * Represents objects selection on stage.
+ * It keep track of objects snapping bounding box
+ * It keep track of objects effective bounding box
+ * Bounding boxes must be represented in canvas coordinate space
  *
  * @author Łukasz Kurzaj lukaszkurzaj@gmail.com
  */
 public class ObjectsSelection {
 
-    private Object objects[];
     private Object object;
-    private Rectangle2D rect;
-
-    public Object[] getObjects() {
-        return objects;
-    }
-
-    public void setObjects(Object[] objects) {
-        this.objects = objects;
-    }
+    private Rectangle2D snappingBoundingBox;
+    private Rectangle2D effectiveBoundingBox;
 
     public Object getObject() {
         return object;
@@ -30,12 +24,20 @@ public class ObjectsSelection {
         this.object = object;
     }
 
-    public Rectangle2D getRect() {
-        return rect;
+    public Rectangle2D getSnappingBoundingBox() {
+        return snappingBoundingBox;
     }
 
-    public void setRect(Rectangle2D rect) {
-        this.rect = rect;
+    public void setSnappingBoundingBox(Rectangle2D snappingBoundingBox) {
+        this.snappingBoundingBox = snappingBoundingBox;
+    }
+
+    public Rectangle2D getEffectiveBoundingBox() {
+        return effectiveBoundingBox;
+    }
+
+    public void setEffectiveBoundingBox(Rectangle2D effectiveBoundingBox) {
+        this.effectiveBoundingBox = effectiveBoundingBox;
     }
 
     public boolean isEmpty() {

--- a/src/main/java/pixelitor/tools/move/ObjectsSelection.java
+++ b/src/main/java/pixelitor/tools/move/ObjectsSelection.java
@@ -1,0 +1,44 @@
+package pixelitor.tools.move;
+
+import java.awt.geom.Rectangle2D;
+
+/**
+ * Represents objects selection on stage. It keep track on objects bounding box
+ * Bounding box must be represented in canvas coordinate space
+ *
+ * @author Łukasz Kurzaj lukaszkurzaj@gmail.com
+ */
+public class ObjectsSelection {
+
+    private Object objects[];
+    private Object object;
+    private Rectangle2D rect;
+
+    public Object[] getObjects() {
+        return objects;
+    }
+
+    public void setObjects(Object[] objects) {
+        this.objects = objects;
+    }
+
+    public Object getObject() {
+        return object;
+    }
+
+    public void setObject(Object object) {
+        this.object = object;
+    }
+
+    public Rectangle2D getRect() {
+        return rect;
+    }
+
+    public void setRect(Rectangle2D rect) {
+        this.rect = rect;
+    }
+
+    public boolean isEmpty() {
+        return object == null;
+    }
+}

--- a/src/main/java/pixelitor/tools/util/UserDrag.java
+++ b/src/main/java/pixelitor/tools/util/UserDrag.java
@@ -33,6 +33,7 @@ import java.awt.geom.Point2D;
  */
 public class UserDrag {
     private boolean dragging;
+    private boolean canceled;
 
     // The coordinates in the component (mouse) space.
     private double coStartX;
@@ -156,6 +157,14 @@ public class UserDrag {
 
     public boolean isDragging() {
         return dragging;
+    }
+
+    public boolean isCanceled() {
+        return canceled;
+    }
+
+    public void cancel() {
+        canceled = true;
     }
 
     public void mouseReleased() {

--- a/src/main/java/pixelitor/utils/ImageTrimUtil.java
+++ b/src/main/java/pixelitor/utils/ImageTrimUtil.java
@@ -1,0 +1,80 @@
+package pixelitor.utils;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
+
+
+/**
+ * Trim image from transparent pixels
+ * See https://stackoverflow.com/questions/3224561/crop-image-to-smallest-size-by-removing-transparent-pixels-in-java
+ *
+ * There could be two possible needs:
+ * 1. Full trim: only pixels that are in format argb (0,0,0,0)
+ * 2. Trim transparent pixels: only pixels with alpha = 0
+ *
+ * @author Łukasz Kurzaj lukaszkurzaj@gmail.com
+ */
+public class ImageTrimUtil {
+    /**
+     * Returns image bounding box trimmed from transparent pixels (alpha channel = 0)
+     */
+    public static Rectangle getTrimRect(BufferedImage image) {
+        WritableRaster raster = image.getAlphaRaster();
+        int width = raster.getWidth();
+        int height = raster.getHeight();
+        int left = 0;
+        int top = 0;
+        int right = width - 1;
+        int bottom = height - 1;
+        int minRight = width - 1;
+        int minBottom = height - 1;
+
+        top:
+        for (; top < bottom; top++) {
+            for (int x = 0; x < width; x++) {
+                if (raster.getSample(x, top, 0) != 0) {
+                    minRight = x;
+                    minBottom = top;
+                    break top;
+                }
+            }
+        }
+
+        left:
+        for (; left < minRight; left++) {
+            for (int y = height - 1; y > top; y--) {
+                if (raster.getSample(left, y, 0) != 0) {
+                    minBottom = y;
+                    break left;
+                }
+            }
+        }
+
+        bottom:
+        for (; bottom > minBottom; bottom--) {
+            for (int x = width - 1; x >= left; x--) {
+                if (raster.getSample(x, bottom, 0) != 0) {
+                    minRight = x;
+                    break bottom;
+                }
+            }
+        }
+
+        right:
+        for (; right > minRight; right--) {
+            for (int y = bottom; y >= top; y--) {
+                if (raster.getSample(right, y, 0) != 0) {
+                    break right;
+                }
+            }
+        }
+
+        return new Rectangle(left, top, right - left + 1, bottom - top + 1);
+    }
+
+    public static BufferedImage trimImage(BufferedImage image) {
+        Rectangle rect = getTrimRect(image);
+        return image.getSubimage(rect.x, rect.y, rect.width, rect.height);
+    }
+}


### PR DESCRIPTION
Work in progress:

1. This auto selection solution use pixel probing for hit detection. Mask layer is taken into consideration. I could not find better way than applying alpha channel manually when calculating final pixel value.

2. For text layer bounding box (or rotated bounding box) is used. I did check PS and they used bounding box even for rotated text. Effects like shadows are omitted from hit detection.

3. I used some thresholds to omit almost transparent pixels.

4. This is work in progress because of bounding box issues. I think the best way is to:
    a) use implicit call imageChanged() to indicate any changes to the image
    b) imageChanged then calls updateIconImage() and any other needed methods to keep things synchronized. In other words replace updateIconImage with more general method imageChanged
