### PR TITLE
Add files needed for flatpak packaging

### DIFF
--- a/flatpak/io.sourceforge.Pixelitor.desktop
+++ b/flatpak/io.sourceforge.Pixelitor.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Pixelitor
+GenericName=Image Editor
+Comment=Pixelitor is an open source image editor that supports layers, layer masks, text layers, filters, multiple undo etc.
+Exec=pixelitor
+Icon=io.sourceforge.Pixelitor
+Terminal=false
+Type=Application
+Keywords=pixelitor;graphic;design;illustration;painting;
+Categories=Graphics;2DGraphics;RasterGraphics;
+MimeType=application/x-pixelator;image/openraster;image/jpeg;image/png;image/x-icon;image/gif;image/bmp;
+StartupNotify=false

--- a/flatpak/io.sourceforge.Pixelitor.metainfo.xml
+++ b/flatpak/io.sourceforge.Pixelitor.metainfo.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.sourceforge.Pixelitor</id>
+  <launchable type="desktop-id">io.sourceforge.Pixelitor.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <developer_name>László Balázs-Csíki</developer_name>
+  <name>Pixelitor</name>
+  <summary>Pixelitor is an open source image editor</summary>
+  <description>
+    <p>
+    	Pixelitor is an advanced image editor with support for layers, layer masks, text layers, multiple undo, blending modes, cropping, Gaussian blurring, unsharp masking, histograms, etc. It has more than 110 image filters and color adjustments, some of which are unique to Pixelitor. Some of the gradients are unique to Pixelator.
+    </p>
+  </description>
+  <screenshots>
+  	<screenshot type="default">
+    <image type="source">https://discourse-flathub-org-uploads.s3.dualstack.us-east-1.amazonaws.com/original/1X/db8831d506107393b6c89191c2a80f0b9534eff4.png</image>
+    <caption>3D Text on Linux</caption>
+    </screenshot>
+    <screenshot>
+    <image type="source">https://pixelitor.sourceforge.io/images/screenshot1.jpg</image>
+    <caption>Glass Tiles Filter</caption>
+    </screenshot>
+    <screenshot>
+    <image type="source">https://pixelitor.sourceforge.io/images/screenshot2.jpg</image>
+    <caption>Photo Collage Filter</caption>
+    </screenshot>
+    <screenshot>
+    <image type="source">https://pixelitor.sourceforge.io/images/screenshot3.jpg</image>
+    <caption>Render Marble</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://pixelitor.sourceforge.io/</url>
+  <update_contact>nbenitezl_AT_gmail.com</update_contact>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="4.2.3" date="2019-12-11">
+    <description>
+      <ul>
+          <li>Brush outline in the Brush, Eraser, Smudge and Clone Tools</li>
+          <li>Create selection from the text of a text layer</li>
+          <li>Move selection in the Move Tool</li>
+          <li>Copy/paste for selections</li>
+          <li>Selection crop can be nonrectangular (with generated layer masks)</li>
+          <li>"Color randomness" option in the "Spray Shapes Brush"</li>
+          <li>"Image Source" option and Hue/Saturation distances in the "Mask from Color Range"</li>
+          <li>Add layer mask from transparency and from layer contents</li>
+          <li>Chaos Game, Mandelbrot and Julia fractal renderers</li>
+          <li>"Watermarking" option for the Render/Shapes filters</li>
+          <li>Minor bugfixes and UI improvements</li>
+      </ul>
+    </description>
+    <url>https://github.com/lbalazscs/Pixelitor/releases/tag/v4.2.3</url>
+    </release>
+  </releases>
+</component>

--- a/flatpak/io.sourceforge.Pixelitor.mime.xml
+++ b/flatpak/io.sourceforge.Pixelitor.mime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="application/x-pixelator">
+        <comment>Pixelator image file</comment>
+        <glob pattern="*.pxc"/>
+    </mime-type>
+</mime-info>


### PR DESCRIPTION
To be published on https://flathub.org/ which is a new distro-agnostic linux app store.

This new flatpak directory should be shipped inside the distributed released .jar file, so please help me with that as I'm not very up to date on java packaging.

The github thread about adding Pixelitor to https://flathub.org/ is in https://github.com/flathub/flathub/pull/2034 I would appreciate if you can join there and leave a comment  on whether you're OK with adding Pixelator to flathub.

Let me know any of your comments! 

Thank you :-)