### PR TITLE
Update texts_fr.properties

### DIFF
--- a/src/main/resources/texts_fr.properties
+++ b/src/main/resources/texts_fr.properties
@@ -178,7 +178,7 @@ radius=Rayon
 linked=Lié
 presets=Préréglages
 builtin_presets=Préréglages intégrés
-brush=Brosse
+brush=Pinceau
 type=Type
 
 # Move Tool


### PR DESCRIPTION
"Brush" in the context of drawing and painting is "pinceau" in French, not "brosse".