### PR TITLE
Add Image Straighten action with reference-line UI

### DIFF
--- a/src/main/java/pixelitor/compactions/SimpleCompAction.java
+++ b/src/main/java/pixelitor/compactions/SimpleCompAction.java
@@ -28,6 +28,7 @@ import pixelitor.history.History;
 import pixelitor.layers.ContentLayer;
 import pixelitor.layers.Layer;
 import pixelitor.layers.SmartObject;
+import pixelitor.layers.TextLayer;
 import pixelitor.selection.SelectionActions;
 import pixelitor.utils.Messages;
 
@@ -57,6 +58,10 @@ public abstract class SimpleCompAction extends AbstractViewEnabledAction impleme
     public CompletableFuture<Composition> process(Composition srcComp) {
         if (disableForSmartObjects() && srcComp.containsLayerOfType(SmartObject.class)) {
             Messages.showSmartObjectUnsupportedWarning(getText());
+            return CompletableFuture.completedFuture(srcComp);
+        }
+        if (disableForTextLayers() && srcComp.containsLayerOfType(TextLayer.class)) {
+            Messages.showTextLayerUnsupportedWarning(getText());
             return CompletableFuture.completedFuture(srcComp);
         }
 
@@ -100,6 +105,10 @@ public abstract class SimpleCompAction extends AbstractViewEnabledAction impleme
     }
 
     public abstract boolean disableForSmartObjects();
+
+    protected boolean disableForTextLayers() {
+        return false;
+    }
 
     private void transformLayer(Layer layer) {
         if (layer instanceof ContentLayer contentLayer) {

--- a/src/main/java/pixelitor/compactions/Straighten.java
+++ b/src/main/java/pixelitor/compactions/Straighten.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Laszlo Balazs-Csiki and Contributors
+ *
+ * This file is part of Pixelitor. Pixelitor is free software: you
+ * can redistribute it and/or modify it under the terms of the GNU
+ * General Public License, version 3 as published by the Free
+ * Software Foundation.
+ *
+ * Pixelitor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Pixelitor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pixelitor.compactions;
+
+import pixelitor.Canvas;
+import pixelitor.gui.View;
+import pixelitor.guides.Guides;
+import pixelitor.layers.ContentLayer;
+
+import java.awt.geom.AffineTransform;
+
+/**
+ * Rotates all layers around the canvas center by an arbitrary angle.
+ */
+public class Straighten extends SimpleCompAction {
+    public static final String NAME = "Straighten";
+
+    private final double angleDegrees;
+    private final double angleRadians;
+
+    public Straighten(double angleDegrees) {
+        super(NAME, false);
+        this.angleDegrees = angleDegrees;
+        this.angleRadians = Math.toRadians(angleDegrees);
+    }
+
+    @Override
+    public boolean disableForSmartObjects() {
+        return true;
+    }
+
+    @Override
+    protected boolean disableForTextLayers() {
+        return true;
+    }
+
+    @Override
+    protected void updateCanvasSize(Canvas newCanvas, View view) {
+        // no-op, straighten keeps the canvas size unchanged
+    }
+
+    @Override
+    protected String getEditName() {
+        return NAME;
+    }
+
+    @Override
+    protected void transform(ContentLayer contentLayer) {
+        contentLayer.rotate(angleRadians, false);
+    }
+
+    @Override
+    protected AffineTransform createCanvasTransform(Canvas canvas) {
+        var center = canvas.getImCenter();
+        return AffineTransform.getRotateInstance(
+            angleRadians, center.getX(), center.getY());
+    }
+
+    @Override
+    protected Guides createTransformedGuides(Guides srcGuides, View view, Canvas srcCanvas) {
+        // Arbitrary-angle guide transform is not available yet.
+        return srcGuides.copyIdentical(view);
+    }
+
+    @Override
+    protected String getStatusBarMessage() {
+        return "Image straightened by " + String.format("%.2f°", angleDegrees);
+    }
+}

--- a/src/main/java/pixelitor/compactions/StraightenPanel.java
+++ b/src/main/java/pixelitor/compactions/StraightenPanel.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Laszlo Balazs-Csiki and Contributors
+ *
+ * This file is part of Pixelitor. Pixelitor is free software: you
+ * can redistribute it and/or modify it under the terms of the GNU
+ * General Public License, version 3 as published by the Free
+ * Software Foundation.
+ *
+ * Pixelitor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Pixelitor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pixelitor.compactions;
+
+import pixelitor.Composition;
+import pixelitor.gui.utils.DialogBuilder;
+import pixelitor.gui.utils.GridBagHelper;
+
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.GridBagLayout;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.geom.Line2D;
+import java.awt.image.BufferedImage;
+
+import static java.awt.Color.RED;
+import static java.awt.Color.WHITE;
+import static java.awt.RenderingHints.KEY_ANTIALIASING;
+import static java.awt.RenderingHints.KEY_INTERPOLATION;
+import static java.awt.RenderingHints.VALUE_ANTIALIAS_ON;
+import static java.awt.RenderingHints.VALUE_INTERPOLATION_BILINEAR;
+
+/**
+ * Dialog panel for the straighten action.
+ */
+public class StraightenPanel extends JPanel implements ChangeListener {
+    private final JSpinner angleSpinner;
+    private final ReferenceLinePanel referenceLinePanel;
+    private boolean updatingAngleFromLine = false;
+
+    private StraightenPanel(Composition comp) {
+        setLayout(new GridBagLayout());
+        var gbh = new GridBagHelper(this);
+
+        referenceLinePanel = new ReferenceLinePanel(comp.getCompositeImage(), this::setAngleFromLine);
+        gbh.addFullRow(referenceLinePanel);
+
+        angleSpinner = new JSpinner(new SpinnerNumberModel(0.0, -180.0, 180.0, 0.1));
+        angleSpinner.addChangeListener(this);
+        gbh.addLabelAndControl("Angle (degrees):", angleSpinner);
+
+        gbh.addFullRow(new JLabel("<html>Draw a line that should become horizontal.<br>"
+            + "The angle is calculated automatically, and you can still fine-tune it."));
+    }
+
+    private double getAngleDegrees() {
+        return ((Number) angleSpinner.getValue()).doubleValue();
+    }
+
+    private void setAngleFromLine(double angleDegrees) {
+        updatingAngleFromLine = true;
+        angleSpinner.setValue(angleDegrees);
+        updatingAngleFromLine = false;
+    }
+
+    @Override
+    public void stateChanged(ChangeEvent e) {
+        if (!updatingAngleFromLine) {
+            referenceLinePanel.repaint();
+        }
+    }
+
+    public static void showInDialog(Composition comp) {
+        StraightenPanel panel = new StraightenPanel(comp);
+        new DialogBuilder()
+            .title(Straighten.NAME)
+            .content(panel)
+            .okAction(() ->
+                new Straighten(panel.getAngleDegrees()).process(comp))
+            .show();
+    }
+
+    private static class ReferenceLinePanel extends JPanel {
+        private static final int MAX_PREVIEW_WIDTH = 540;
+        private static final int MAX_PREVIEW_HEIGHT = 340;
+        private static final int PADDING = 8;
+
+        private final BufferedImage image;
+        private final java.util.function.DoubleConsumer angleConsumer;
+        private Point start;
+        private Point end;
+
+        private ReferenceLinePanel(BufferedImage image, java.util.function.DoubleConsumer angleConsumer) {
+            this.image = image;
+            this.angleConsumer = angleConsumer;
+            setBorder(BorderFactory.createTitledBorder("Reference Line"));
+
+            int prefWidth = Math.min(MAX_PREVIEW_WIDTH, image.getWidth() + PADDING * 2);
+            int prefHeight = Math.min(MAX_PREVIEW_HEIGHT, image.getHeight() + PADDING * 2);
+            setPreferredSize(new java.awt.Dimension(prefWidth, prefHeight));
+
+            MouseAdapter mouseHandler = new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    Point p = clampToImage(e.getPoint());
+                    start = p;
+                    end = p;
+                    repaint();
+                }
+
+                @Override
+                public void mouseDragged(MouseEvent e) {
+                    if (start == null) {
+                        return;
+                    }
+
+                    end = clampToImage(e.getPoint());
+                    updateAngleFromCurrentLine();
+                    repaint();
+                }
+            };
+            addMouseListener(mouseHandler);
+            addMouseMotionListener(mouseHandler);
+        }
+
+        @Override
+        protected void paintComponent(java.awt.Graphics g) {
+            super.paintComponent(g);
+            java.awt.Graphics2D g2 = (java.awt.Graphics2D) g.create();
+            try {
+                g2.setRenderingHint(KEY_INTERPOLATION, VALUE_INTERPOLATION_BILINEAR);
+                g2.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
+
+                Rectangle imageRect = getImageRect();
+                g2.drawImage(image, imageRect.x, imageRect.y, imageRect.width, imageRect.height, null);
+
+                if (start != null && end != null) {
+                    g2.setColor(WHITE);
+                    g2.setStroke(new java.awt.BasicStroke(3.0f));
+                    g2.draw(new Line2D.Double(start, end));
+
+                    g2.setColor(RED);
+                    g2.setStroke(new java.awt.BasicStroke(1.5f));
+                    g2.draw(new Line2D.Double(start, end));
+                }
+            } finally {
+                g2.dispose();
+            }
+        }
+
+        private Rectangle getImageRect() {
+            int availableWidth = getWidth() - PADDING * 2;
+            int availableHeight = getHeight() - PADDING * 2;
+            if (availableWidth <= 0 || availableHeight <= 0) {
+                return new Rectangle(PADDING, PADDING, 1, 1);
+            }
+
+            double sx = availableWidth / (double) image.getWidth();
+            double sy = availableHeight / (double) image.getHeight();
+            double scale = Math.min(sx, sy);
+
+            int drawWidth = Math.max(1, (int) Math.round(image.getWidth() * scale));
+            int drawHeight = Math.max(1, (int) Math.round(image.getHeight() * scale));
+            int drawX = (getWidth() - drawWidth) / 2;
+            int drawY = (getHeight() - drawHeight) / 2;
+
+            return new Rectangle(drawX, drawY, drawWidth, drawHeight);
+        }
+
+        private Point clampToImage(Point input) {
+            Rectangle imageRect = getImageRect();
+            int x = Math.max(imageRect.x, Math.min(imageRect.x + imageRect.width, input.x));
+            int y = Math.max(imageRect.y, Math.min(imageRect.y + imageRect.height, input.y));
+            return new Point(x, y);
+        }
+
+        private void updateAngleFromCurrentLine() {
+            if (start == null || end == null || start.equals(end)) {
+                return;
+            }
+            double dx = end.x - start.x;
+            double dy = end.y - start.y;
+            double degrees = -Math.toDegrees(Math.atan2(dy, dx));
+            angleConsumer.accept(Math.round(degrees * 100.0) / 100.0);
+        }
+    }
+}

--- a/src/main/java/pixelitor/layers/ContentLayer.java
+++ b/src/main/java/pixelitor/layers/ContentLayer.java
@@ -207,6 +207,14 @@ public abstract class ContentLayer extends Layer {
     public abstract void rotate(QuadrantAngle angle, boolean layerTransform);
 
     /**
+     * Rotates the layer content by an arbitrary angle (in radians).
+     */
+    public void rotate(double angleRadians, boolean layerTransform) {
+        throw new UnsupportedOperationException(getClass().getSimpleName()
+            + " does not support arbitrary-angle rotation.");
+    }
+
+    /**
      * Adjusts the layer content in response to canvas enlargement.
      */
     public abstract void enlargeCanvas(Outsets out);

--- a/src/main/java/pixelitor/layers/GradientFillLayer.java
+++ b/src/main/java/pixelitor/layers/GradientFillLayer.java
@@ -199,6 +199,16 @@ public class GradientFillLayer extends ContentLayer {
     }
 
     @Override
+    public void rotate(double angleRadians, boolean layerTransform) {
+        if (gradient != null) {
+            var center = comp.getCanvas().getImCenter();
+            gradient.imTransform(AffineTransform.getRotateInstance(
+                angleRadians, center.getX(), center.getY()));
+            invalidateGradientCache();
+        }
+    }
+
+    @Override
     public void enlargeCanvas(Outsets out) {
         if (gradient != null) {
             gradient.enlargeCanvas(out);

--- a/src/main/java/pixelitor/layers/ImageLayer.java
+++ b/src/main/java/pixelitor/layers/ImageLayer.java
@@ -689,6 +689,30 @@ public class ImageLayer extends ContentLayer implements Drawable, Transformable 
         }
     }
 
+    @Override
+    public void rotate(double angleRadians, boolean layerTransform) {
+        if (Math.abs(angleRadians) < 1.0e-12) {
+            return;
+        }
+
+        Point2D canvasCenter = comp.getCanvas().getImCenter();
+        AffineTransform at = AffineTransform.getRotateInstance(
+            angleRadians, canvasCenter.getX(), canvasCenter.getY());
+        at.translate(getTx(), getTy());
+
+        TransformResult result = applyTransform(image, at, VALUE_INTERPOLATION_BILINEAR);
+        if (result == null) {
+            throw new IllegalStateException("transform resulted in an empty image");
+        }
+
+        if (layerTransform) {
+            replaceTranslatedImage(result.image, "Rotate Layer", result.tx, result.ty);
+        } else {
+            setTranslation(result.tx, result.ty);
+            setImage(result.image);
+        }
+    }
+
     // this is a layer-only transform, the canvas does not change
     private void rotateOnlyThisLayer(QuadrantAngle angle) {
         Point2D canvasCenter = comp.getCanvas().getImCenter();

--- a/src/main/java/pixelitor/layers/ShapesLayer.java
+++ b/src/main/java/pixelitor/layers/ShapesLayer.java
@@ -193,6 +193,13 @@ public class ShapesLayer extends ContentLayer {
     }
 
     @Override
+    public void rotate(double angleRadians, boolean layerTransform) {
+        var center = comp.getCanvas().getImCenter();
+        transform(AffineTransform.getRotateInstance(
+            angleRadians, center.getX(), center.getY()));
+    }
+
+    @Override
     public void enlargeCanvas(Outsets out) {
         transform(AffineTransform.getTranslateInstance(out.left, out.top));
     }

--- a/src/main/java/pixelitor/layers/TextLayer.java
+++ b/src/main/java/pixelitor/layers/TextLayer.java
@@ -385,6 +385,11 @@ public class TextLayer extends ContentLayer implements DialogMenuOwner {
     }
 
     @Override
+    public void rotate(double angleRadians, boolean layerTransform) {
+        throw new UnsupportedOperationException("TextLayer arbitrary-angle rotation is not implemented.");
+    }
+
+    @Override
     public CompletableFuture<Void> resize(Dimension newSize) {
         // TODO
         return CompletableFuture.completedFuture(null);

--- a/src/main/java/pixelitor/menus/MenuBar.java
+++ b/src/main/java/pixelitor/menus/MenuBar.java
@@ -601,6 +601,10 @@ public class MenuBar extends JMenuBar {
         imageMenu.addSeparator();
 
         // rotate
+        imageMenu.addViewEnabled(Straighten.NAME + "...",
+            StraightenPanel::showInDialog);
+        imageMenu.addSeparator();
+
         imageMenu.add(new Rotate(ANGLE_90), "comp_rot_90");
         imageMenu.add(new Rotate(ANGLE_180), "comp_rot_180");
         imageMenu.add(new Rotate(ANGLE_270), "comp_rot_270");

--- a/src/main/java/pixelitor/utils/Messages.java
+++ b/src/main/java/pixelitor/utils/Messages.java
@@ -168,6 +168,11 @@ public class Messages {
             what + " isn't yet supported if one of the layers is a smart object.", null);
     }
 
+    public static void showTextLayerUnsupportedWarning(String what) {
+        msgHandler.showInfo("Feature Not Supported",
+            what + " isn't yet supported if one of the layers is a text layer.", null);
+    }
+
     public static void showFileOpenedMessage(Composition comp) {
         showStatusMessage("<b>" + comp.getName() + "</b> ("
             + comp.getCanvas().getSizeString() + ") was opened.");

--- a/src/test/java/pixelitor/compactions/CompActionTest.java
+++ b/src/test/java/pixelitor/compactions/CompActionTest.java
@@ -29,6 +29,8 @@ import pixelitor.TestHelper;
 import pixelitor.gui.View;
 import pixelitor.history.History;
 import pixelitor.layers.ImageLayer;
+import pixelitor.layers.SmartObject;
+import pixelitor.layers.TextLayer;
 import pixelitor.testutils.LayerCount;
 import pixelitor.testutils.WithMask;
 import pixelitor.testutils.WithSelection;
@@ -41,6 +43,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static pixelitor.assertions.PixelitorAssertions.assertThat;
 import static pixelitor.compactions.QuadrantAngle.ANGLE_180;
 
@@ -352,6 +356,44 @@ class CompActionTest {
             flippedSelOrigin.x, flippedSelOrigin.y,
             origSelection.width, origSelection.height
         ));
+    }
+
+    @Test
+    void straighten() {
+        testActionWithUndoRedo(
+            new Straighten(5.0),
+            Straighten.NAME,
+            comp -> checkStateAfterStraighten());
+    }
+
+    private void checkStateAfterStraighten() {
+        Composition straightenedComp = view.getComp();
+        assertThat(straightenedComp)
+            .canvasSizeIs(ORIG_CANVAS_WIDTH, ORIG_CANVAS_HEIGHT);
+
+        ImageLayer activeLayer = (ImageLayer) straightenedComp.getActiveLayer();
+        assertTrue(activeLayer.getImage().getWidth() >= ORIG_CANVAS_WIDTH);
+        assertTrue(activeLayer.getImage().getHeight() >= ORIG_CANVAS_HEIGHT);
+    }
+
+    @Test
+    void straightenWithTextLayerIsRejected() {
+        TextLayer textLayer = TestHelper.createTextLayer(origComp, "text");
+        origComp.addLayerWithoutUI(textLayer);
+
+        Composition result = new Straighten(5.0).process(origComp).join();
+        assertSame(origComp, result);
+        History.assertNumEditsIs(0);
+    }
+
+    @Test
+    void straightenWithSmartObjectIsRejected() {
+        SmartObject smartObject = (SmartObject) TestHelper.createLayer(SmartObject.class, origComp);
+        origComp.addLayerWithoutUI(smartObject);
+
+        Composition result = new Straighten(5.0).process(origComp).join();
+        assertSame(origComp, result);
+        History.assertNumEditsIs(0);
     }
 
     @Test


### PR DESCRIPTION
This PR adds a first working version of Image > Straighten....

What’s included:

New Straighten... entry under the Image menu
A straighten dialog with a draggable reference line on preview
Auto angle calculation from the drawn line, with manual fine-tuning
Composition-level rotation on OK (not just active layer)
Proper undo/redo history entry

Supported:
ImageLayer
ShapesLayer
GradientFillLayer
masks (through existing comp action traversal)

Not supported:
compositions containing TextLayer
compositions containing SmartObject
In these cases, the action shows an unsupported message and exits without changes.

Implementation notes:

Added Straighten and StraightenPanel
Added arbitrary-angle rotate entry point on ContentLayer
Implemented arbitrary-angle rotation for supported layer types
Added a text-layer guard to SimpleCompAction for this action

Tests:
Added straighten coverage in CompActionTest:
basic straighten behavior
undo/redo
rejection with TextLayer
rejection with SmartObject
Ran: mvn -Dtest=CompActionTest test (pass)